### PR TITLE
feat: support decode function data

### DIFF
--- a/lib/src/contracts/abi/abi.dart
+++ b/lib/src/contracts/abi/abi.dart
@@ -273,6 +273,21 @@ class ContractFunction {
     final parsedData = tuple.decode(buffer, 0);
     return parsedData.data;
   }
+
+  /// Decode the data for a function call (e.g. tx.data)
+  List<dynamic> decodeFunctionData(String data) {
+    if (data.startsWith('0x')) {
+      data = data.substring(2);
+    }
+    if (!data.toLowerCase().startsWith(bytesToHex(selector).toLowerCase())) {
+      throw Exception('Must match selector');
+    }
+    final tuple = TupleType(parameters.map((p) => p.type).toList());
+    final buffer = hexToBytes(data.substring(8)).buffer;
+
+    final parsedData = tuple.decode(buffer, 0);
+    return parsedData.data;
+  }
 }
 
 /// An event that can be emitted by a smart contract during a transaction.


### PR DESCRIPTION
Interface decodeFunctionData in [docs](https://docs.ethers.org/v5/api/utils/abi/interface/
)

Example: Data Hex for approve 100 USDC (0x6131B5fae19EA4f9D964eAc0408E4408b66337b5)
Input: 0x095ea7b30000000000000000000000006131b5fae19ea4f9d964eac0408e4408b66337b50000000000000000000000000000000000000000000000000000000005f5e100

Output: ["0x6131B5fae19EA4f9D964eAc0408E4408b66337b5", 100000000]